### PR TITLE
Fixed bug with small name change in credentials

### DIFF
--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -31,10 +31,14 @@ export class GithubTrigger implements INodeType {
 		inputs: [],
 		outputs: ['main'],
 		credentials: [
+			// {
+			// 	name: 'githubApi',
+			// 	required: true,
+			// }, 
 			{
-				name: 'githubApi',
+				name: 'githubOAuth2Api',
 				required: true,
-			}
+			}, 
 		],
 		webhooks: [
 			{


### PR DESCRIPTION
The GitHub trigger was not requesting the correct credentials, which was resulting in a bug where I could not select the correct credentials and therefore could not use the GitHub Trigger. I solved this by updating the credentials array in the GitHub Trigger object.

I ran `npm test` successfully.