### PR TITLE
Prompt save

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -435,8 +435,10 @@ export default mixins(
 
 					saveAs(blob, workflowName + '.json');
 				} else if (key === 'workflow-save') {
+					console.log("saving......");
 					this.saveCurrentWorkflow();
 				} else if (key === 'workflow-save-as') {
+					console.log("saving......");
 					this.saveCurrentWorkflow(true);
 				} else if (key === 'help-about') {
 					this.aboutDialogVisible = true;

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -443,13 +443,28 @@ export default mixins(
 				} else if (key === 'workflow-settings') {
 					this.workflowSettingsDialogVisible = true;
 				} else if (key === 'workflow-new') {
-					this.$router.push({ name: 'NodeViewNew' });
+					const workflowId = this.$store.getters.workflowId;
+					const result = await this.dataHasChanged(workflowId);
+					if(result) {
+						const importConfirm = await this.confirmMessage(`When you switch workflows your current workflow changes will be lost.`, 'Save your Changes?', 'warning', 'Yes, switch workflows and forget changes');
+						if (importConfirm === true) {
+							this.$router.push({ name: 'NodeViewNew' });
 
-					this.$showMessage({
-						title: 'Workflow created',
-						message: 'A new workflow got created!',
-						type: 'success',
-					});
+							this.$showMessage({
+								title: 'Workflow created',
+								message: 'A new workflow got created!',
+								type: 'success',
+							});
+						}
+					} else {
+						this.$router.push({ name: 'NodeViewNew' });
+
+						this.$showMessage({
+							title: 'Workflow created',
+							message: 'A new workflow got created!',
+							type: 'success',
+						});
+					}
 				} else if (key === 'credentials-open') {
 					this.credentialOpenDialogVisible = true;
 				} else if (key === 'credentials-new') {

--- a/packages/editor-ui/src/components/WorkflowOpen.vue
+++ b/packages/editor-ui/src/components/WorkflowOpen.vue
@@ -33,6 +33,7 @@ import WorkflowActivator from '@/components/WorkflowActivator.vue';
 
 import { restApi } from '@/components/mixins/restApi';
 import { genericHelpers } from '@/components/mixins/genericHelpers';
+import { workflowHelpers } from '@/components/mixins/workflowHelpers';
 import { showMessage } from '@/components/mixins/showMessage';
 import { IWorkflowShortResponse } from '@/Interface';
 
@@ -42,6 +43,7 @@ export default mixins(
 	genericHelpers,
 	restApi,
 	showMessage,
+	workflowHelpers,
 ).extend({
 	name: 'WorkflowOpen',
 	props: [
@@ -87,9 +89,20 @@ export default mixins(
 			this.$emit('closeDialog');
 			return false;
 		},
-		openWorkflow (data: IWorkflowShortResponse, column: any) { // tslint:disable-line:no-any
+		async openWorkflow (data: IWorkflowShortResponse, column: any) { // tslint:disable-line:no-any
 			if (column.label !== 'Active') {
-				this.$emit('openWorkflow', data.id);
+				const workflowId = this.$store.getters.workflowId;
+				const result = await this.dataHasChanged(workflowId);
+				if(result) {
+					const importConfirm = await this.confirmMessage(`When you switch workflows your current workflow changes will be lost.`, 'Save your Changes?', 'warning', 'Yes, switch workflows and forget changes');
+					if (importConfirm === false) {
+						return;
+					} else {
+						this.$emit('openWorkflow', data.id);
+					}
+				} else {
+					this.$emit('openWorkflow', data.id);
+				}
 			}
 		},
 		openDialog () {

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -488,8 +488,6 @@ export const workflowHelpers = mixins(
 				data = await this.restApi().getWorkflow(id);
 
 				if(data !== undefined) {
-					console.log(currentData);
-					console.log(data);
 					const x = {
 						nodes: data.nodes,
 						connections: data.connections,

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -22,6 +22,7 @@ import {
 	INodeTypesMaxCount,
 	INodeUi,
 	IWorkflowData,
+	IWorkflowDb,
 	IWorkflowDataUpdate,
 	XYPositon,
 } from '../../Interface';
@@ -29,6 +30,8 @@ import {
 import { restApi } from '@/components/mixins/restApi';
 import { nodeHelpers } from '@/components/mixins/nodeHelpers';
 import { showMessage } from '@/components/mixins/showMessage';
+
+import { isEqual } from 'lodash';
 
 import mixins from 'vue-typed-mixins';
 
@@ -477,6 +480,32 @@ export const workflowHelpers = mixins(
 					node.position[0] += offsetPosition[0];
 					node.position[1] += offsetPosition[1];
 				}
+			},
+			async dataHasChanged(id: string) {
+				const currentData = await this.getWorkflowDataToSave();
+
+				let data: IWorkflowDb;
+				data = await this.restApi().getWorkflow(id);
+
+				if(data !== undefined) {
+					console.log(currentData);
+					console.log(data);
+					const x = {
+						nodes: data.nodes,
+						connections: data.connections,
+						settings: data.settings,
+						name: data.name
+					};
+					const y = {
+						nodes: currentData.nodes,
+						connections: currentData.connections,
+						settings: currentData.settings,
+						name: currentData.name
+					};
+					return !isEqual(x, y);
+				}
+
+				return true;
 			},
 		},
 	});

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -187,7 +187,7 @@ export default mixins(
 				this.createNodeActive = false;
 			},
 			nodes: {
-				handler: async function (val, oldVal) {
+				async handler (val, oldVal) {
 					// Load a workflow
 					let workflowId = null as string | null;
 					if (this.$route && this.$route.params.name) {
@@ -198,12 +198,11 @@ export default mixins(
 					} else {
 						this.isDirty = true;
 					}
-					console.log(this.isDirty);
 				},
 				deep: true
 			},
 			connections: {
-				handler: async function (val, oldVal) {
+				async handler (val, oldVal) {
 					// Load a workflow
 					let workflowId = null as string | null;
 					if (this.$route && this.$route.params.name) {
@@ -214,7 +213,6 @@ export default mixins(
 					} else {
 						this.isDirty = true;
 					}
-					console.log(this.isDirty);
 				},
 				deep: true
 			},
@@ -1373,6 +1371,8 @@ export default mixins(
 								+ 'If you leave before saving, your changes will be lost.';
 						(e || window.event).returnValue = confirmationMessage; //Gecko + IE
 						return confirmationMessage; //Gecko + Webkit, Safari, Chrome etc.
+					} else {
+						return;
 					}
 				});
 			},

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1328,6 +1328,10 @@ export default mixins(
 
 				document.addEventListener('keydown', this.keyDown);
 				document.addEventListener('keyup', this.keyUp);
+				window.onbeforeunload = this.confirmSave;
+			},
+			async confirmSave(e: Event) {
+				window.confirm();
 			},
 			__addConnection (connection: [IConnection, IConnection], addVisualConnection = false) {
 				if (addVisualConnection === true) {


### PR DESCRIPTION
### :wrench: Prompt the user to save changes before reload as in this [issue](https://github.com/MLH-Fellowship/n8n/issues/47).

I cannot set a custom message because of new [security restrictions](https://stackoverflow.com/questions/38879742/is-it-possible-to-display-a-custom-message-in-the-beforeunload-popup/38880926).

#### This feature works in all the following cases:
- User makes changes --> prompt will show
- User makes changes and saves with ⌘S --> prompt will not show
- User makes changes and attempts to switch workflows or open a new workflow --> prompt will show
- User makes changes, saves with sidebar or ⌘S, and attempts to switch workflows or open a new workflow --> prompt will not show
#### The feature does not work in this case:
- User makes changes and saves with sidebar button --> prompt will show despite save

I was not able to figure out the final case without major changes to the frontend, let me know if you have advice or if I should just leave it as is!